### PR TITLE
Make queryOptions more clear in example

### DIFF
--- a/doc-js/query-using-json.md
+++ b/doc-js/query-using-json.md
@@ -91,7 +91,8 @@ An additional reason for this format is that it supports the concept of allowing
      expand: ["orderDetails","orderDetails.product"],
      skip:20,
      take:10,
-     inlineCount:true
+     inlineCount:true,
+     queryOptions: {fetchStrategy:'FromLocalCache', mergeStrategy:'PreserveChanges'}
     }
 
 


### PR DESCRIPTION
include queryOptions in example along with all the other options. (param options are already at the bottom of doc)
